### PR TITLE
chore: trigger release-notes-docs-pr after release creation

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -119,5 +119,13 @@ jobs:
           gh workflow run use-shared-publish.yml --ref master
           echo "Triggered use-shared-publish.yml"
 
+      - name: Trigger Release Notes Docs PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.check-release.outputs.version }}"
+          gh workflow run release-notes-docs-pr.yml --ref master --field tag="v$VERSION" --field dry_run=false
+          echo "Triggered release-notes-docs-pr.yml for v$VERSION"
+
       - name: Summary
         run: echo "Release published" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

GitHub Actions does not fire downstream workflow triggers (like `release: published`) for events created by `GITHUB_TOKEN`. This means `release-notes-docs-pr.yml` never auto-fires after an automated release.

**Fix:** Explicitly dispatch `release-notes-docs-pr.yml` via `gh workflow run` after the GitHub release is created in `release-publish.yml`.

## Test plan

- [ ] Merge and trigger a release — verify `release-notes-docs-pr.yml` runs automatically
- [ ] Alternatively, run `release-publish.yml` via workflow_dispatch and confirm the docs PR workflow is triggered